### PR TITLE
#7 fix : 스크립트 중복 추가 문제 해결

### DIFF
--- a/public/js/components/loginForm.js
+++ b/public/js/components/loginForm.js
@@ -1,8 +1,11 @@
 function loginForm() {
-  const link = document.createElement("link");
-  link.rel = "stylesheet";
-  link.href = "/css/login.css";
-  document.head.appendChild(link);
+  // 이미 스타일시트가 로드되어 있는지 확인
+  if (!document.querySelector('link[href="/css/login.css"]')) {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "/css/login.css";
+    document.head.appendChild(link);
+  }
 
   const content = `
     <form id="loginForm">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -5,6 +5,12 @@ const navigateTo = (url) => {
 
 const loadComponent = (scriptSrc) => {
   return new Promise((resolve, reject) => {
+    if (document.querySelector(`script[src="${scriptSrc}"]`)) {
+      // <script> 태그가 이미 존재하는 경우 Promise를 resolve
+      resolve();
+      return;
+    }
+
     const script = document.createElement("script");
     script.src = scriptSrc;
     script.onload = () => resolve();


### PR DESCRIPTION
## 작업 내용

- login 페이지로 이동할 때마다 동일한 스크립트가 여러 번 로드되어 성능 저하와 불필요한 네트워크 요청이 발생하는 문제 해결

## 주요 변경 사항

- 스크립트를 추가하기 전에 해당 스크립트가 이미 로드되었는지를 확인하도록 loadComponent 함수를 수정.
  - document.querySelector를 사용하여 <script> 태그 중 src 속성이 일치하는 것이 있는지를 확인하고, 이미 존재할 경우 새로운 로드를 건너뜀.
- 스타일시트(link 태그)에 대해서도 동일한 방법을 적용하여 중복 추가를 방지.

## 범위 외 커밋

-

## 참고
- Closes #
- Sub of #
- reference link1
